### PR TITLE
REAMDE | Update syntax, fix misc linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,73 @@
-[![Build Status][travis-image]][travis-url]
+<!-- omit in toc -->
+# go-teams-notify
+
+A package to send messages to Microsoft Teams (channels)
+
 [![Github Tag][githubtag-image]][githubtag-url]
-
-[![Coverage Status][coveralls-image]][coveralls-url]
-[![Maintainability][codeclimate-image]][codeclimate-url]
-[![codecov][codecov-image]][codecov-url]
-
-[![Go Report Card][goreport-image]][goreport-url]
 [![GoDoc][godoc-image]][godoc-url]
 [![License][license-image]][license-url]
 
-***
+<!-- omit in toc -->
+## Table of contents
 
-# go-teams-notify
+- [Usage](#usage)
+- [References](#references)
 
-> A package to send messages to Microsoft Teams (channels)
-
-...
-
-# Usage
+## Usage
 
 To get the package, execute:
 
-```
-go get https://github.com/dasrick/go-teams-notify/v2
+```console
+go get https://github.com/atc0005/go-teams-notify/v2
 ```
 
 To import this package, add the following line to your code:
 
-```
-import "github.com/dasrick/go-teams-notify/v2"
+```golang
+import "github.com/atc0005/go-teams-notify/v2"
 ```
 
 And this is an example of a simple implementation ...
 
-```
+```golang
 import (
-	"github.com/dasrick/go-teams-notify/v2"
+  "github.com/atc0005/go-teams-notify/v2"
 )
 
 func main() {
-	_ = sendTheMessage()
+  _ = sendTheMessage()
 }
 
 func sendTheMessage() error {
-	// init the client
-	mstClient := goteamsnotify.NewClient()
+  // init the client
+  mstClient := goteamsnotify.NewClient()
 
-	// setup webhook url
-	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+  // setup webhook url
+  webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
 
-	// setup message card
-	msgCard := goteamsnotify.NewMessageCard()
-	msgCard.Title = "Hello world"
-	msgCard.Text = "Here are some examples of formatted stuff like <br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
-	msgCard.ThemeColor = "#DF813D"
+  // setup message card
+  msgCard := goteamsnotify.NewMessageCard()
+  msgCard.Title = "Hello world"
+  msgCard.Text = "Here are some examples of formatted stuff like "+
+      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+  msgCard.ThemeColor = "#DF813D"
 
-	// send
-	return mstClient.Send(webhookUrl, msgCard)
+  // send
+  return mstClient.Send(webhookUrl, msgCard)
 }
 ```
 
-# <a id="links"></a>some useful links
+## References
 
-* [MS Teams - adaptive cards](https://docs.microsoft.com/de-de/outlook/actionable-messages/adaptive-card)
-* [MS Teams - send via connectors](https://docs.microsoft.com/de-de/outlook/actionable-messages/send-via-connectors)
-* [adaptivecards.io](https://adaptivecards.io/designer)
+- [MS Teams - adaptive cards](https://docs.microsoft.com/de-de/outlook/actionable-messages/adaptive-card)
+- [MS Teams - send via connectors](https://docs.microsoft.com/de-de/outlook/actionable-messages/send-via-connectors)
+- [adaptivecards.io](https://adaptivecards.io/designer)
 
-***
+[githubtag-image]: https://img.shields.io/github/tag/atc0005/go-teams-notify.svg?style=flat
+[githubtag-url]: https://github.com/atc0005/go-teams-notify
 
-[travis-image]: https://travis-ci.org/dasrick/go-teams-notify.svg?branch=master
-[travis-url]: https://travis-ci.org/dasrick/go-teams-notify
+[godoc-image]: https://godoc.org/github.com/atc0005/go-teams-notify?status.svg
+[godoc-url]: https://godoc.org/github.com/atc0005/go-teams-notify
 
-[githubtag-image]: https://img.shields.io/github/tag/dasrick/go-teams-notify.svg?style=flat
-[githubtag-url]: https://github.com/dasrick/go-teams-notify
-
-[coveralls-image]: https://coveralls.io/repos/github/dasrick/go-teams-notify/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/dasrick/go-teams-notify?branch=master
-
-[codeclimate-image]: https://api.codeclimate.com/v1/badges/fe69cc992370b3f97d94/maintainability
-[codeclimate-url]: https://codeclimate.com/github/dasrick/go-teams-notify/maintainability
-
-[codecov-image]: https://codecov.io/gh/dasrick/go-teams-notify/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/dasrick/go-teams-notify
-
-[goreport-image]: https://goreportcard.com/badge/github.com/dasrick/go-teams-notify
-[goreport-url]: https://goreportcard.com/report/github.com/dasrick/go-teams-notify
-
-[godoc-image]: https://godoc.org/github.com/dasrick/go-teams-notify?status.svg
-[godoc-url]: https://godoc.org/github.com/dasrick/go-teams-notify
-
-[license-image]: https://img.shields.io/github/license/dasrick/go-teams-notify.svg?style=flat
-[license-url]: https://github.com/dasrick/go-teams-notify/blob/master/LICENSE
+[license-image]: https://img.shields.io/github/license/atc0005/go-teams-notify.svg?style=flat
+[license-url]: https://github.com/atc0005/go-teams-notify/blob/master/LICENSE


### PR DESCRIPTION
- Replace `dasrick` with `atc0005` where applicable
- Remove CI badges specific to services that `dasrick` used for the parent project
- Fix misc linting issues regarding whitespace, headers and so forth