### PR TITLE
Remove correct local lint config path in CI

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -32,7 +32,7 @@ jobs:
           # Remove the copy of the config file bundled with the repo/code so
           # that the configuration provided by the atc0005/go-ci project is
           # used instead
-          rm -vf .golangci.yml
+          rm -vf .golangci.yaml
 
       - name: Run golangci-lint using container-provided config file settings
         run: golangci-lint run -v

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -30,7 +30,7 @@ jobs:
           # Remove the copy of the config file bundled with the repo/code so
           # that the configuration provided by the atc0005/go-ci project is
           # used instead
-          rm -vf .golangci.yml
+          rm -vf .golangci.yaml
 
       - name: Run golangci-lint using container-provided config file settings
         run: golangci-lint run -v


### PR DESCRIPTION
The golangci-lint config file in this repo is named with a different extension than I use elsewhere. Update the
GitHub Action Workflow files to reference the correct local filename for this repo.