### PR TITLE
Replace IsType assert with Go 1.13 error wrapping

### DIFF
--- a/send.go
+++ b/send.go
@@ -93,7 +93,7 @@ func IsValidWebhookURL(webhookURL string) (bool, error) {
 		u, err := url.Parse(webhookURL)
 		if err != nil {
 			return false, fmt.Errorf(
-				"unable to parse webhook URL %q: %v",
+				"unable to parse webhook URL %q: %w",
 				webhookURL,
 				err,
 			)


### PR DESCRIPTION
Update table test to filter error result (nil or not) and then apply errors.As() func where non-nil to handle  wrapped errors.

I'm not particularly practiced at writing tests, so there is likely a better way to handle this.

This solves the immediate problem, but more work is needed to account for recent changes that I introduced with prior PRs accepted upstream (and now locally).

fixes GH-23