### PR TITLE
Fix invalid test RoundTripper implementation

### DIFF
--- a/send_test.go
+++ b/send_test.go
@@ -116,6 +116,24 @@ func TestTeamsClientSend(t *testing.T) {
 		client := NewTestClient(func(req *http.Request) (*http.Response, error) {
 			// Test request parameters
 			assert.Equal(t, req.URL.String(), test.reqURL)
+
+			// GH-46; fix contributed by @davecheney (thank you!)
+			//
+			// The RoundTripper documentation notes that nil must be returned
+			// as the error value if a response is received. A non-nil error
+			// should be returned for failure to obtain a response. Failure to
+			// obtain a response is indicated by the test table response
+			// error, so we represent that failure to obtain a response by
+			// returning nil and the test table response error explaining why
+			// a response could not be retrieved.
+			if test.resError != nil {
+				return nil, test.resError
+			}
+
+			// GH-46 (cont) If no table test response errors are provided,
+			// then the response was retrieved (provided below), so we are
+			// required to return nil as the error value along with the
+			// response.
 			return &http.Response{
 				StatusCode: test.resStatus,
 
@@ -124,7 +142,7 @@ func TestTeamsClientSend(t *testing.T) {
 
 				// Must be set to non-nil value or it panics
 				Header: make(http.Header),
-			}, test.resError
+			}, nil
 		})
 		c := &teamsClient{httpClient: client}
 

--- a/send_test.go
+++ b/send_test.go
@@ -181,9 +181,19 @@ func TestTeamsClientSend(t *testing.T) {
 					test.error,
 					err,
 				)
+				t.Logf(
+					"OK: test %d; test.error has value '%s'",
+					idx,
+					test.error.Error(),
+				)
+				t.Logf(
+					"OK: test %d; error response has value '%s'",
+					idx,
+					err.Error(),
+				)
 			}
 		} else {
-			t.Logf("OK: test %d; no error", idx)
+			t.Logf("OK: test %d; no error; response body: '%s'", idx, test.resBody)
 		}
 	}
 }


### PR DESCRIPTION
## CHANGES

Apply fix provided by `davecheney` in order to properly implement the RoundTripper interface's expected behavior:

- return response and nil error OR
- return nil and a non-nil error to explain failures to obtain a response

I likely *over* explained this with doc comments, but I am still very much in "learning" mode here.

## REFERENCES

### This project

- fixes GH-46
- 2ce144fffe3eab0da3282a80bc2a5ebdd58f1a42
- 6db6217e7daac6da6ed43dd7cf02032a22c84af2

### Official / Guides

- https://github.com/golang/go/issues/41071
- https://github.com/golang/go/issues/38095
    - https://github.com/golang/go/commit/2d77d3330537e11a0d9a233ba5f4facf262e9d8c
    - https://github.com/golang/go/commit/12d02e7d8e7df75ccbf07ec40028329fcc35c55b
- https://godoc.org/net/http#RoundTripper
- https://godoc.org/net/http#Response
    - https://godoc.org/net/http#Response.Body
- http://hassansin.github.io/Unit-Testing-http-client-in-Go