### PR TITLE
Enable verbose test output by default

### DIFF
--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Run golangci-lint using container-provided config file settings
         run: golangci-lint run -v
 
-      - name: Run all tests
-        run: go test -mod=vendor -v ./...
+      - name: Run all tests recursively, verbosely
+        run: go test -v -mod=vendor -v ./...

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ linting:
 ## gotests: runs go test recursively, verbosely
 gotests:
 	@echo "Running go tests ..."
-	@go test -mod=vendor ./...
+	@go test -v -mod=vendor ./...
 	@echo "Finished running go tests"
 
 .PHONY: goclean


### PR DESCRIPTION
The Makefile doc comments make this clear that verbose
outut was the original intention.

Precursor to some test logic review work (where verbose output
will come in handy).