### PR TITLE
Adjust receiver type to permit field changes

### DIFF
--- a/send.go
+++ b/send.go
@@ -248,8 +248,9 @@ func (c teamsClient) SendWithRetry(ctx context.Context, webhookURL string, webho
 	return result
 }
 
-// SkipWebhookUrlValidationOnSend Optionally do not validate the webhook URL.
-func (c teamsClient) SkipWebhookURLValidationOnSend(skip bool) {
+// SkipWebhookURLValidationOnSend allows the caller to optionally disable
+// webhook URL prefix validation.
+func (c *teamsClient) SkipWebhookURLValidationOnSend(skip bool) {
 	c.skipWebhookURLValidation = skip
 }
 


### PR DESCRIPTION
Allow the `SkipWebhookURLValidationOnSend` method to modify the `skipWebhookURLValidation` field so that the intended behavior is applied.

refs GH-68
refs GH-69
refs GH-73