### PR TITLE
Modify webhook URL prefix validation to use regex

### DIFF
--- a/send.go
+++ b/send.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -29,8 +30,29 @@ var logger *log.Logger
 
 // Known webhook URL prefixes for submitting messages to Microsoft Teams
 const (
-	WebhookURLOfficecomPrefix = "https://outlook.office.com"
-	WebhookURLOffice365Prefix = "https://outlook.office365.com"
+	WebhookURLOfficecomPrefix  = "https://outlook.office.com"
+	WebhookURLOffice365Prefix  = "https://outlook.office365.com"
+	WebhookURLOrgWebhookPrefix = "https://example.webhook.office.com"
+)
+
+// Regular Expression related constants that we can use to validate incoming
+// webhook URLs provided by the user.
+const (
+
+	// webhookURLRegexPrefixOnly is a minimal regex for matching known valid
+	// webhook URL prefix patterns.
+	webhookURLRegexPrefixOnly = `^https:\/\/(?:.*\.webhook|outlook)\.office(?:365)?\.com`
+
+	// Note: The regex allows for capital letters in the GUID patterns. This is
+	// allowed based on light testing which shows that mixed case works and the
+	// assumption that since Teams and Office 365 are Microsoft products case
+	// would be ignored (e.g., Windows, IIS do not consider 'A' and 'a' to be
+	// different).
+	// webhookURLRegex           = `^https:\/\/(?:.*\.webhook|outlook)\.office(?:365)?\.com\/webhook(?:b2)?\/[-a-zA-Z0-9]{36}@[-a-zA-Z0-9]{36}\/IncomingWebhook\/[-a-zA-Z0-9]{32}\/[-a-zA-Z0-9]{36}$`
+
+	// webhookURLSubURIWebhookPrefix         = "webhook"
+	// webhookURLSubURIWebhookb2Prefix       = "webhookb2"
+	// webhookURLOfficialDocsSampleURI       = "a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c"
 )
 
 // ExpectedWebhookURLResponseText represents the expected response text
@@ -308,25 +330,28 @@ func IsValidInput(webhookMessage MessageCard, webhookURL string) (bool, error) {
 // IsValidWebhookURL performs validation checks on the webhook URL used to
 // submit messages to Microsoft Teams.
 func IsValidWebhookURL(webhookURL string) (bool, error) {
-	switch {
-	case strings.HasPrefix(webhookURL, WebhookURLOfficecomPrefix):
-	case strings.HasPrefix(webhookURL, WebhookURLOffice365Prefix):
-	default:
-		u, err := url.Parse(webhookURL)
-		if err != nil {
-			return false, fmt.Errorf(
-				"unable to parse webhook URL %q: %w",
-				webhookURL,
-				err,
-			)
-		}
+	u, err := url.Parse(webhookURL)
+	if err != nil {
+		return false, fmt.Errorf(
+			"unable to parse webhook URL %q: %w",
+			webhookURL,
+			err,
+		)
+	}
+
+	matched, err := regexp.MatchString(webhookURLRegexPrefixOnly, webhookURL)
+	if !matched {
 		userProvidedWebhookURLPrefix := u.Scheme + "://" + u.Host
 
+		errMsg := "validation failed"
+		if err != nil {
+			errMsg = err.Error()
+		}
+
 		return false, fmt.Errorf(
-			"webhook URL %q received; expected one of %q or %q: %w",
+			"webhook URL %q received; %v: %w",
 			userProvidedWebhookURLPrefix,
-			WebhookURLOfficecomPrefix,
-			WebhookURLOffice365Prefix,
+			errMsg,
 			ErrWebhookURLUnexpectedPrefix,
 		)
 	}


### PR DESCRIPTION
Use a regex to validate known webhook URL prefix patterns.

While a longer, very specific pattern has been tested and appears to work as intended, this commit replaces existing fixed string matches with one lighter regex that handles prefix matches.

refs GH-84