### PR TITLE
Better webhooks validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,45 @@ func sendTheMessage() error {
 }
 ```
 
+### Example: Enable custom patterns' validation
+
+This example demonstrates how to enable custom validation patterns for webhook URLs.
+
+```golang
+import (
+  "github.com/atc0005/go-teams-notify/v2"
+)
+
+func main() {
+  _ = sendTheMessage()
+}
+
+func sendTheMessage() error {
+  // init the client
+  mstClient := goteamsnotify.NewClient()
+
+  // setup webhook url
+  webhookUrl := "https://my.domain.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+  // Add a custom pattern for webhook URL validation
+  mstClient.AddWebhookURLValidationPatterns(`^https://.*\.domain\.com/.*$`)
+  // It's also possible to use multiple patterns with one call
+  // mstClient.AddWebhookURLValidationPatterns(`^https://arbitrary\.example\.com/webhook/.*$`, `^https://.*\.domain\.com/.*$`)
+  // To keep the default behavior and add a custom one, use something like the following:
+  // mstClient.AddWebhookURLValidationPatterns(DefaultWebhookURLValidationPattern, `^https://.*\.domain\.com/.*$`)
+
+  // setup message card
+  msgCard := goteamsnotify.NewMessageCard()
+  msgCard.Title = "Hello world"
+  msgCard.Text = "Here are some examples of formatted stuff like "+
+      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+  msgCard.ThemeColor = "#DF813D"
+
+  // send
+  return mstClient.Send(webhookUrl, msgCard)
+}
+```
+
 Of note:
 
 - webhook URL validation is **disabled**

--- a/send_test.go
+++ b/send_test.go
@@ -168,6 +168,17 @@ func TestTeamsClientSend(t *testing.T) {
 			skipURLVal:            false,
 			validationURLPatterns: []string{DefaultWebhookURLValidationPattern, "arbitrary.domain.com"},
 		},
+		// custom webhook domain with complex custom validation pattern matching requirements
+		{
+			reqURL:                "https://foo.domain.com/webhook/xxx",
+			reqMsg:                simpleMsgCard,
+			resStatus:             200,
+			resBody:               ExpectedWebhookURLResponseText,
+			resError:              nil,
+			error:                 nil,
+			skipURLVal:            false,
+			validationURLPatterns: []string{`^https://.*\.domain\.com/.*$`},
+		},
 	}
 	for idx, test := range tests {
 		// Create range scoped var for use within closure


### PR DESCRIPTION
- `MessageCard` can now be validated with a custom validation func
- send `API` now supports custom webhook patterns for URL validation (added to the ability to deactivating it)