### PR TITLE
Update node-version val to use latest LTS version

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -23,10 +23,11 @@ jobs:
 
     steps:
       - name: Setup Node
-        # https://github.com/actions/setup-node
+        # https://github.com/actions/setup-node#supported-version-syntax
+        # https://github.com/nvm-sh/nvm#long-term-support
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: "10.x"
+          node-version: "lts/*"
 
       - name: Install Markdown linting tools
         run: |


### PR DESCRIPTION
Replace hard-coded version with LTS alias for "latest version", supported by the most recent `actions/setup-node` update.

refs GH-105
