### PR TITLE
Migrate examples from README to standalone files

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,43 +191,9 @@ shadabacc3934](https://gist.github.com/chusiang/895f6406fbf9285c58ad0a3ace13d025
 
 ### Example: Basic
 
-Here is an example of a simple client application which uses this library:
+This is an example of a simple client application which uses this library.
 
-```golang
-import (
-  "github.com/atc0005/go-teams-notify/v2"
-)
-
-func main() {
-  _ = sendTheMessage()
-}
-
-func sendTheMessage() error {
-  // init the client
-  mstClient := goteamsnotify.NewClient()
-
-  // setup webhook url
-  webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
-
-  // setup message card
-  msgCard := goteamsnotify.NewMessageCard()
-  msgCard.Title = "Hello world"
-  msgCard.Text = "Here are some examples of formatted stuff like "+
-      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
-  msgCard.ThemeColor = "#DF813D"
-
-  // send
-  return mstClient.Send(webhookUrl, msgCard)
-}
-```
-
-Of note:
-
-- default timeout
-- package-level logging is disabled by default
-- validation of known webhook URL prefixes is *enabled*
-- simple message submitted to Microsoft Teams consisting of formatted body and
-  title
+File: [basic](./examples/basic/main.go)
 
 ### Example: Add an Action
 
@@ -235,72 +201,7 @@ This example illustrates adding an [`OpenUri Action`][msgcard-ref-actions] to
 a message card. When used, this action triggers opening a URI in a separate
 browser or application.
 
-```golang
-package main
-
-import (
-  "log"
-
-  "github.com/atc0005/go-teams-notify/v2"
-)
-
-func main() {
-  _ = sendTheMessage()
-}
-
-func sendTheMessage() error {
-  // init the client
-  mstClient := goteamsnotify.NewClient()
-
-  // setup webhook url
-  webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
-
-  // destination for OpenUri action
-  targetURL := "https://github.com/atc0005/go-teams-notify"
-  targetURLDesc := "Project Homepage"
-
-  // setup message card
-  msgCard := goteamsnotify.NewMessageCard()
-  msgCard.Title = "Hello world"
-  msgCard.Text = "Here are some examples of formatted stuff like "+
-      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
-  msgCard.ThemeColor = "#DF813D"
-
-  // setup Action for message card
-  pa, err := goteamsnotify.NewMessageCardPotentialAction(
-    goteamsnotify.PotentialActionOpenURIType,
-    targetURLDesc,
-  )
-
-  if err != nil {
-    log.Fatal("error encountered when creating new action:", err)
-  }
-
-  pa.MessageCardPotentialActionOpenURI.Targets =
-    []goteamsnotify.MessageCardPotentialActionOpenURITarget{
-      {
-        OS:  "default",
-        URI: targetURL,
-      },
-    }
-
-  // add the Action to the message card
-  if err := msgCard.AddPotentialAction(pa); err != nil {
-    log.Fatal("error encountered when adding action to message card:", err)
-  }
-
-  // send
-  return mstClient.Send(webhookUrl, msgCard)
-}
-```
-
-Of note:
-
-- default timeout
-- package-level logging is disabled by default
-- validation of known webhook URL prefixes is *enabled*
-- message submitted to Microsoft Teams consisting of formatted body, title and
-  one [`OpenUri Action`][msgcard-ref-actions]
+File: [actions](./examples/actions/main.go)
 
 ### Example: Disable webhook URL prefix validation
 
@@ -308,87 +209,14 @@ This example disables the validation webhook URLs, including the validation of
 known prefixes so that custom/private webhook URL endpoints can be used (e.g.,
 testing purposes).
 
-```golang
-import (
-  "github.com/atc0005/go-teams-notify/v2"
-)
-
-func main() {
-  _ = sendTheMessage()
-}
-
-func sendTheMessage() error {
-  // init the client
-  mstClient := goteamsnotify.NewClient()
-
-  // setup webhook url
-  webhookUrl := "https://example.webhook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
-
-  // Disable webhook URL validation
-  mstClient.SkipWebhookURLValidationOnSend(true)
-
-  // setup message card
-  msgCard := goteamsnotify.NewMessageCard()
-  msgCard.Title = "Hello world"
-  msgCard.Text = "Here are some examples of formatted stuff like "+
-      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
-  msgCard.ThemeColor = "#DF813D"
-
-  // send
-  return mstClient.Send(webhookUrl, msgCard)
-}
-```
-
-Of note:
-
-- webhook URL validation is **disabled**
-  - allows use of custom/private webhook URL endpoints
-- other settings are the same as the basic example previously listed
+File: [disable-validation](./examples/disable-validation/main.go)
 
 ### Example: Enable custom patterns' validation
 
-This example demonstrates how to enable custom validation patterns for webhook URLs.
+This example demonstrates how to enable custom validation patterns for webhook
+URLs.
 
-```golang
-import (
-  "github.com/atc0005/go-teams-notify/v2"
-)
-
-func main() {
-  _ = sendTheMessage()
-}
-
-func sendTheMessage() error {
-  // init the client
-  mstClient := goteamsnotify.NewClient()
-
-  // setup webhook url
-  webhookUrl := "https://my.domain.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
-
-  // Add a custom pattern for webhook URL validation
-  mstClient.AddWebhookURLValidationPatterns(`^https://.*\.domain\.com/.*$`)
-  // It's also possible to use multiple patterns with one call
-  // mstClient.AddWebhookURLValidationPatterns(`^https://arbitrary\.example\.com/webhook/.*$`, `^https://.*\.domain\.com/.*$`)
-  // To keep the default behavior and add a custom one, use something like the following:
-  // mstClient.AddWebhookURLValidationPatterns(DefaultWebhookURLValidationPattern, `^https://.*\.domain\.com/.*$`)
-
-  // setup message card
-  msgCard := goteamsnotify.NewMessageCard()
-  msgCard.Title = "Hello world"
-  msgCard.Text = "Here are some examples of formatted stuff like "+
-      "<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
-  msgCard.ThemeColor = "#DF813D"
-
-  // send
-  return mstClient.Send(webhookUrl, msgCard)
-}
-```
-
-Of note:
-
-- webhook URL validation uses custom pattern
-  - allows use of custom/private webhook URL endpoints
-- other settings are the same as the basic example previously listed
+File: [custom-validation](./examples/custom-validation/main.go)
 
 ## Used by
 

--- a/examples/actions/main.go
+++ b/examples/actions/main.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+
+This example illustrates adding an [`OpenUri Action`][msgcard-ref-actions] to
+a message card. When used, this action triggers opening a URI in a separate
+browser or application.
+
+
+Of note:
+
+- default timeout
+- package-level logging is disabled by default
+- validation of known webhook URL prefixes is *enabled*
+- message submitted to Microsoft Teams consisting of formatted body, title and
+  one [`OpenUri Action`][msgcard-ref-actions]
+
+*/
+
+package main
+
+import (
+	"log"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+)
+
+func main() {
+	_ = sendTheMessage()
+}
+
+func sendTheMessage() error {
+	// init the client
+	mstClient := goteamsnotify.NewClient()
+
+	// setup webhook url
+	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	// destination for OpenUri action
+	targetURL := "https://github.com/atc0005/go-teams-notify"
+	targetURLDesc := "Project Homepage"
+
+	// setup message card
+	msgCard := goteamsnotify.NewMessageCard()
+	msgCard.Title = "Hello world"
+	msgCard.Text = "Here are some examples of formatted stuff like " +
+		"<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+	msgCard.ThemeColor = "#DF813D"
+
+	// setup Action for message card
+	pa, err := goteamsnotify.NewMessageCardPotentialAction(
+		goteamsnotify.PotentialActionOpenURIType,
+		targetURLDesc,
+	)
+
+	if err != nil {
+		log.Fatal("error encountered when creating new action:", err)
+	}
+
+	pa.MessageCardPotentialActionOpenURI.Targets =
+		[]goteamsnotify.MessageCardPotentialActionOpenURITarget{
+			{
+				OS:  "default",
+				URI: targetURL,
+			},
+		}
+
+	// add the Action to the message card
+	if err := msgCard.AddPotentialAction(pa); err != nil {
+		log.Fatal("error encountered when adding action to message card:", err)
+	}
+
+	// send
+	return mstClient.Send(webhookUrl, msgCard)
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+
+This is an example of a simple client application which uses this library.
+
+Of note:
+
+- default timeout
+- package-level logging is disabled by default
+- validation of known webhook URL prefixes is *enabled*
+- simple message submitted to Microsoft Teams consisting of formatted body and
+  title
+
+*/
+
+package main
+
+import (
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+)
+
+func main() {
+	_ = sendTheMessage()
+}
+
+func sendTheMessage() error {
+	// init the client
+	mstClient := goteamsnotify.NewClient()
+
+	// setup webhook url
+	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	// setup message card
+	msgCard := goteamsnotify.NewMessageCard()
+	msgCard.Title = "Hello world"
+	msgCard.Text = "Here are some examples of formatted stuff like " +
+		"<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+	msgCard.ThemeColor = "#DF813D"
+
+	// send
+	return mstClient.Send(webhookUrl, msgCard)
+}

--- a/examples/custom-validation/main.go
+++ b/examples/custom-validation/main.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+
+This example demonstrates how to enable custom validation patterns for webhook
+URLs.
+
+Of note:
+
+- webhook URL validation uses custom pattern
+  - allows use of custom/private webhook URL endpoints
+- other settings are the same as the basic example previously listed
+
+*/
+
+package main
+
+import (
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+)
+
+func main() {
+	_ = sendTheMessage()
+}
+
+func sendTheMessage() error {
+	// init the client
+	mstClient := goteamsnotify.NewClient()
+
+	// setup webhook url
+	webhookUrl := "https://my.domain.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	// Add a custom pattern for webhook URL validation
+	mstClient.AddWebhookURLValidationPatterns(`^https://.*\.domain\.com/.*$`)
+	// It's also possible to use multiple patterns with one call
+	// mstClient.AddWebhookURLValidationPatterns(`^https://arbitrary\.example\.com/webhook/.*$`, `^https://.*\.domain\.com/.*$`)
+	// To keep the default behavior and add a custom one, use something like the following:
+	// mstClient.AddWebhookURLValidationPatterns(DefaultWebhookURLValidationPattern, `^https://.*\.domain\.com/.*$`)
+
+	// setup message card
+	msgCard := goteamsnotify.NewMessageCard()
+	msgCard.Title = "Hello world"
+	msgCard.Text = "Here are some examples of formatted stuff like " +
+		"<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+	msgCard.ThemeColor = "#DF813D"
+
+	// send
+	return mstClient.Send(webhookUrl, msgCard)
+}

--- a/examples/disable-validation/main.go
+++ b/examples/disable-validation/main.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+
+This example disables the validation webhook URLs, including the validation of
+known prefixes so that custom/private webhook URL endpoints can be used (e.g.,
+testing purposes).
+
+Of note:
+
+- webhook URL validation is **disabled**
+  - allows use of custom/private webhook URL endpoints
+- other settings are the same as the basic example previously listed
+
+*/
+
+package main
+
+import (
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+)
+
+func main() {
+	_ = sendTheMessage()
+}
+
+func sendTheMessage() error {
+	// init the client
+	mstClient := goteamsnotify.NewClient()
+
+	// setup webhook url
+	webhookUrl := "https://example.webhook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	// Disable webhook URL validation
+	mstClient.SkipWebhookURLValidationOnSend(true)
+
+	// setup message card
+	msgCard := goteamsnotify.NewMessageCard()
+	msgCard.Title = "Hello world"
+	msgCard.Text = "Here are some examples of formatted stuff like " +
+		"<br> * this list itself  <br> * **bold** <br> * *italic* <br> * ***bolditalic***"
+	msgCard.ThemeColor = "#DF813D"
+
+	// send
+	return mstClient.Send(webhookUrl, msgCard)
+}


### PR DESCRIPTION
Move examples out of README so that CI checks can assert that the examples (at a minimum) still build correctly whenever repo content changes.

fixes GH-113