### PR TITLE
Allow overriding default http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ information.
     validation behavior
 - Configurable timeouts
 - Configurable retry support
+- Support for overriding the default `http.Client`
 
 ## Project Status
 

--- a/doc.go
+++ b/doc.go
@@ -33,6 +33,8 @@ FEATURES
 
 • Configurable retry support
 
+• Support for overriding the default http.Client
+
 
 USAGE
 

--- a/send.go
+++ b/send.go
@@ -89,6 +89,7 @@ type API interface {
 	Send(webhookURL string, webhookMessage MessageCard) error
 	SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error
 	SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error
+	SetHTTPClient(httpClient *http.Client) API
 	SkipWebhookURLValidationOnSend(skip bool) API
 	AddWebhookURLValidationPatterns(patterns ...string) API
 	ValidateWebhook(webhookURL string) error
@@ -131,6 +132,14 @@ func NewClient() API {
 		skipWebhookURLValidation: false,
 	}
 	return &client
+}
+
+// SetHTTPClient accepts a custom http.Client value which replaces the
+// existing default http.Client.
+func (c *teamsClient) SetHTTPClient(httpClient *http.Client) API {
+	c.httpClient = httpClient
+
+	return c
 }
 
 func (c *teamsClient) AddWebhookURLValidationPatterns(patterns ...string) API {


### PR DESCRIPTION
- Add `teamsClient.SetHTTPClient()` method to allow client code to replace default `http.Client` with custom value
- Update `API` interface to expose new `SetHTTPClient()` method
- Light doc updates to reflect this change

fixes GH-135