### PR TITLE
Fix incorrect field name reference in error msg

### DIFF
--- a/messagecard.go
+++ b/messagecard.go
@@ -535,7 +535,7 @@ func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
 		}
 
 		if f.Value == "" {
-			return fmt.Errorf("empty Name field received for new fact: %+v", f)
+			return fmt.Errorf("empty Value field received for new fact: %+v", f)
 		}
 	}
 


### PR DESCRIPTION
Incorrect field referenced in error message for `MessageCardSection.AddFact()`.

fixes GH-144