### PR TITLE
Refactor `teamsClient.SendWith*` methods

### DIFF
--- a/send.go
+++ b/send.go
@@ -183,50 +183,21 @@ func (c teamsClient) Send(webhookURL string, webhookMessage MessageCard) error {
 func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error {
 	logger.Printf("SendWithContext: Webhook message received: %#v\n", webhookMessage)
 
-	// optionally skip webhook validation
-	if c.skipWebhookURLValidation {
-		logger.Printf("SendWithContext: Webhook URL will not be validated: %#v\n", webhookURL)
-	}
-
-	// Validate input data
-	if err := c.validateInput(webhookMessage, webhookURL); err != nil {
+	webhookMessageBuffer, err := c.prepareMessageCard(webhookURL, webhookMessage)
+	if err != nil {
 		return err
 	}
 
-	// prepare message
-	webhookMessageByte, _ := json.Marshal(webhookMessage)
-	webhookMessageBuffer := bytes.NewBuffer(webhookMessageByte)
-
-	// Basic, unformatted JSON
-	// logger.Printf("SendWithContext: %+v\n", string(webhookMessageByte))
-
-	var prettyJSON bytes.Buffer
-	if err := json.Indent(&prettyJSON, webhookMessageByte, "", "\t"); err != nil {
+	req, err := c.prepareRequest(ctx, webhookURL, webhookMessageBuffer)
+	if err != nil {
 		return err
 	}
-	logger.Printf("SendWithContext: Payload for Microsoft Teams: \n\n%v\n\n", prettyJSON.String())
 
-	// prepare request (error not possible)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, webhookMessageBuffer)
-	req.Header.Add("Content-Type", "application/json;charset=utf-8")
-
-	// If provided, override the project-specific user agent with custom value.
-	switch {
-	case c.userAgent != "":
-		req.Header.Set("User-Agent", c.userAgent)
-	default:
-		req.Header.Set("User-Agent", DefaultUserAgent)
-	}
-
-	// do the request
+	// Submit message to endpoint.
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		logger.Println(err)
 		return err
-	}
-
-	if ctx.Err() != nil {
-		logger.Println("SendWithContext: Context has expired after Do(req):", time.Now().Format("15:04:05"))
 	}
 
 	// Make sure that we close the response body once we're done with it
@@ -236,53 +207,14 @@ func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, web
 		}
 	}()
 
-	// Get the response body, then convert to string for use with extended
-	// error messages
-	responseData, err := ioutil.ReadAll(res.Body)
+	responseText, err := processResponse(res)
 	if err != nil {
-		logger.Println(err)
 		return err
 	}
-	responseString := string(responseData)
 
-	switch {
-	// 400 Bad Response is likely an indicator that we failed to provide a
-	// required field in our JSON payload. For example, when leaving out the
-	// top level MessageCard Summary or Text field, the remote API returns
-	// "Summary or Text is required." as a text string. We include that
-	// response text in the error message that we return to the caller.
-	case res.StatusCode >= 299:
-		err = fmt.Errorf("error on notification: %v, %q", res.Status, responseString)
-		logger.Println(err)
-		return err
+	logger.Printf("SendWithContext: Response string from Microsoft Teams API: %v\n", responseText)
 
-	// Microsoft Teams developers have indicated that a 200 status code is
-	// insufficient to confirm that a message was successfully submitted.
-	// Instead, clients should ensure that a specific response string was also
-	// returned along with a 200 status code to confirm that a message was
-	// sent successfully. Because there is a chance that unintentional
-	// whitespace could be included, we explicitly strip it out.
-	//
-	// See atc0005/go-teams-notify#59 for more information.
-	case responseString != strings.TrimSpace(ExpectedWebhookURLResponseText):
-
-		err = fmt.Errorf(
-			"got %q, expected %q: %w",
-			responseString,
-			ExpectedWebhookURLResponseText,
-			ErrInvalidWebhookURLResponseText,
-		)
-
-		logger.Println(err)
-		return err
-
-	default:
-
-		// log the response string
-		logger.Printf("SendWithContext: Response string from Microsoft Teams API: %v\n", responseString)
-
-		return nil
-	}
+	return nil
 }
 
 // SendWithRetry is a wrapper function around the SendWithContext method in
@@ -365,6 +297,109 @@ func (c teamsClient) validateInput(webhookMessage MessageCard, webhookURL string
 
 	// validate message
 	return webhookMessage.Validate()
+}
+
+// prepareMessageCard is a helper method to handle tasks needed to prepare a
+// given webhook MessageCard for delivery to an endpoint.
+func (c teamsClient) prepareMessageCard(webhookURL string, webhookMessage MessageCard) (*bytes.Buffer, error) {
+	if c.skipWebhookURLValidation {
+		logger.Printf("prepareMessageCard: Webhook URL will not be validated: %#v\n", webhookURL)
+	}
+
+	if err := c.validateInput(webhookMessage, webhookURL); err != nil {
+		return nil, err
+	}
+
+	webhookMessageByte, err := json.Marshal(webhookMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	webhookMessageBuffer := bytes.NewBuffer(webhookMessageByte)
+
+	// Basic, unformatted JSON
+	// logger.Printf("prepareMessageCard: %+v\n", string(webhookMessageByte))
+
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, webhookMessageByte, "", "\t"); err != nil {
+		return nil, err
+	}
+	logger.Printf("prepareMessageCard: Payload for Microsoft Teams: \n\n%v\n\n", prettyJSON.String())
+
+	return webhookMessageBuffer, nil
+}
+
+// prepareRequest is a helper method response for preparing a http.Request
+// (including all desired headers) in order to submit a given prepared message
+// to an endpoint.
+func (c teamsClient) prepareRequest(ctx context.Context, webhookURL string, preparedMessage *bytes.Buffer) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, preparedMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	// If provided, override the project-specific user agent with custom value.
+	switch {
+	case c.userAgent != "":
+		req.Header.Set("User-Agent", c.userAgent)
+	default:
+		req.Header.Set("User-Agent", DefaultUserAgent)
+	}
+
+	return req, nil
+}
+
+// processResponse is a helper function responsible for validating a response
+// from an endpoint after submitting a message.
+func processResponse(response *http.Response) (string, error) {
+	// Get the response body, then convert to string for use with extended
+	// error messages
+	responseData, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		logger.Println(err)
+
+		return "", err
+	}
+	responseString := string(responseData)
+
+	switch {
+	// 400 Bad Response is likely an indicator that we failed to provide a
+	// required field in our JSON payload. For example, when leaving out the
+	// top level MessageCard Summary or Text field, the remote API returns
+	// "Summary or Text is required." as a text string. We include that
+	// response text in the error message that we return to the caller.
+	case response.StatusCode >= 299:
+		err = fmt.Errorf("error on notification: %v, %q", response.Status, responseString)
+
+		logger.Println(err)
+
+		return "", err
+
+	// Microsoft Teams developers have indicated that a 200 status code is
+	// insufficient to confirm that a message was successfully submitted.
+	// Instead, clients should ensure that a specific response string was also
+	// returned along with a 200 status code to confirm that a message was
+	// sent successfully. Because there is a chance that unintentional
+	// whitespace could be included, we explicitly strip it out.
+	//
+	// See atc0005/go-teams-notify#59 for more information.
+	case responseString != strings.TrimSpace(ExpectedWebhookURLResponseText):
+		err = fmt.Errorf(
+			"got %q, expected %q: %w",
+			responseString,
+			ExpectedWebhookURLResponseText,
+			ErrInvalidWebhookURLResponseText,
+		)
+
+		logger.Println(err)
+
+		return "", err
+
+	default:
+		return responseString, nil
+	}
 }
 
 // ValidateWebhook applies webhook URL validation unless explicitly disabled.


### PR DESCRIPTION
Changes:

- refactor `teamsClient.SendWithContext()`
  -  break logic out into separate methods/functions to allow for reuse with upcoming work on alternative message payloads.
  - further refactoring is intended
- refactor `teamsClient.SendWithRetry()`
  - rework logic so that standard behavior of handling the error condition occurs first
  - move expired context handling into error handling branch to make clear that we are really just dealing with error and and success evaluation