### PR TITLE
Fix invalid JSON key name for Element.URL field

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -478,7 +478,7 @@ type Element struct {
 	//
 	// https://adaptivecards.io/explorer/Image.html
 	// https://adaptivecards.io/explorer/ImageSet.html
-	URL string `json:"uri,omitempty"`
+	URL string `json:"url,omitempty"`
 
 	// Size controls the size of text within a TextBlock element.
 	Size string `json:"size,omitempty"`


### PR DESCRIPTION
Update the JSON key name to match the field name. I mistakenly used the property type for the field instead of the field name itself.

fixes GH-179