### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -535,7 +535,6 @@ type Container Element
 
 // FactSet is an Element type that groups and displays a series of facts (i.e.
 // name/value pairs) in a tabular form.
-//
 type FactSet Element
 
 // Columns is a collection of Column values.

--- a/adaptivecard/doc.go
+++ b/adaptivecard/doc.go
@@ -27,6 +27,5 @@ https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/
 https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using
 https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#send-adaptive-cards-using-an-incoming-webhook
 https://stackoverflow.com/questions/50753072/microsoft-teams-webhook-generating-400-for-adaptive-card
-
 */
 package adaptivecard

--- a/doc.go
+++ b/doc.go
@@ -6,44 +6,34 @@
 // full license information.
 
 /*
-
 Package goteamsnotify is used to send messages to a Microsoft Teams channel.
 
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/go-teams-notify) for the
 latest code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-
-PURPOSE
+# Purpose
 
 Send messages to a Microsoft Teams channel.
 
+# Features
 
-FEATURES
+  - Submit messages to Microsoft Teams consisting of one or more sections,
+    Facts (key/value pairs), Actions or images (hosted externally)
+  - Support for MessageCard and Adaptive Card messages
+  - Support for Actions, allowing users to take quick actions within Microsoft
+    Teams
+  - Support for user mentions
+  - Configurable validation
+  - Configurable timeouts
+  - Configurable retry support
+  - Support for overriding the default http.Client
+  - Support for overriding the default project-specific user agent
 
-• Submit messages to Microsoft Teams consisting of one or more sections, Facts (key/value pairs), Actions or images (hosted externally)
-
-• Support for MessageCard and Adaptive Card messages
-
-• Support for Actions, allowing users to take quick actions within Microsoft Teams
-
-• Support for user mentions
-
-• Configurable validation
-
-• Configurable timeouts
-
-• Configurable retry support
-
-• Support for overriding the default http.Client
-
-• Support for overriding the default project-specific user agent
-
-USAGE
+# Usage
 
 See our main README for supported settings and examples.
-
 */
 package goteamsnotify

--- a/internal/validator/doc.go
+++ b/internal/validator/doc.go
@@ -14,6 +14,5 @@ Credit to Fabrizio Milo for sharing the original implementation:
 
 - https://stackoverflow.com/a/23960293/903870
 - https://github.com/Mistobaan
-
 */
 package validator


### PR DESCRIPTION
- remove stray whitespace per Go 1.19 fmt linting rules
- apply Go 1.19 specific doc comment syntax changes to doc.go
  file at project root