### PR TITLE
Update isValidWebhookURL method

### DIFF
--- a/send.go
+++ b/send.go
@@ -81,6 +81,7 @@ func isValidWebhookURL(webhookURL string) (bool, error) {
 	switch {
 	case strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/"):
 	case strings.HasPrefix(webhookURL, "https://outlook.office365.com/webhook/"):
+	case strings.Contains(webhookURL, ".office.com/webhookb2/"):
 	default:
 		err = errors.New("invalid ms teams webhook url")
 		return false, err


### PR DESCRIPTION
In the private organization, the URL start with: <company>.office.com/webhookb2/

Note: I am not the author, and while I wanted to propose a similar patch I believe this is the cleanest possible implementation and the patch was submitted as PR to the old repo by the original author.
