### PR TITLE
Add validation for Attachment.Content field

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -914,6 +914,8 @@ func (a Attachment) Validate() error {
 		ErrInvalidType,
 	)
 
+	v.SelfValidate(a.Content)
+
 	return v.Err()
 }
 


### PR DESCRIPTION
Restore validation logic "chain" by adding missing validation step. By adding this step, the validation logic can continue "downwards" or "outwards" to associated types as intended.

NOTE: This change does not affect the ability to disable validation entirely if requested by client code.

fixes GH-208