### PR TITLE
Add initial Adaptive Card Table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A package to send messages to a Microsoft Teams channel.
   - [Examples](#examples)
     - [Basic](#basic)
     - [User Mention](#user-mention)
+    - [Tables](#tables)
     - [Set custom user agent](#set-custom-user-agent)
     - [Add an Action](#add-an-action)
     - [Disable webhook URL prefix validation](#disable-webhook-url-prefix-validation)
@@ -201,6 +202,15 @@ is not available in the legacy `MessageCard` card format.
 - File: [user-mention-verbose](./examples/adaptivecard/user-mention-verbose/main.go)
   - this example does not necessarily reflect an optimal implementation
 
+#### Tables
+
+These examples illustrates the use of a [`Table`][adaptivecard-table]. This
+feature is not available in the legacy `MessageCard` card format.
+
+- File: [table-manually-created](./examples/adaptivecard/table-manually-created/main.go)
+- File: [table-unordered-grid](./examples/adaptivecard/table-unordered-grid/main.go)
+- File: [table-with-headers](./examples/adaptivecard/table-with-headers/main.go)
+
 #### Set custom user agent
 
 This example illustrates setting a custom user agent.
@@ -280,3 +290,4 @@ using either this library or the original project.
 [adaptivecard-ref]: <https://adaptivecards.io/explorer>
 [adaptivecard-ref-actions]: <https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/getting-started>
 [adaptivecard-user-mentions]: <https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format#mention-support-within-adaptive-cards>
+[adaptivecard-table]: <https://adaptivecards.io/explorer/Table.html>

--- a/adaptivecard/getters.go
+++ b/adaptivecard/getters.go
@@ -12,8 +12,7 @@ package adaptivecard
 // for validation and display purposes.
 func supportedElementTypes() []string {
 	// TODO: Confirm whether all types are supported.
-	// NOTE: Based on current docs, version 1.4 is the latest supported at this
-	// time.
+	//
 	// https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#support-for-adaptive-cards
 	// https://adaptivecards.io/explorer/AdaptiveCard.html
 	return []string{
@@ -31,6 +30,7 @@ func supportedElementTypes() []string {
 		TypeElementInputToggle,
 		TypeElementMedia, // Introduced in version 1.1 (TODO: Is this supported in Teams message?)
 		TypeElementRichTextBlock,
+		TypeElementTable, // Introduced in version 1.5
 		TypeElementTextBlock,
 		TypeElementTextRun,
 	}
@@ -91,6 +91,32 @@ func supportedSpacingValues() []string {
 		SpacingLarge,
 		SpacingExtraLarge,
 		SpacingPadding,
+	}
+}
+
+// supportedHorizontalAlignmentValues returns a list of valid horizontal
+// content alignment values for supported container types. This list is
+// intended to be used for validation and display purposes.
+func supportedHorizontalContentAlignmentValues() []string {
+	// https://adaptivecards.io/explorer/Table.html
+	// https://adaptivecards.io/schemas/adaptive-card.json
+	return []string{
+		HorizontalAlignmentLeft,
+		HorizontalAlignmentCenter,
+		HorizontalAlignmentRight,
+	}
+}
+
+// supportedVerticalAlignmentValues returns a list of valid vertical content
+// alignment values for supported container types. This list is intended to be
+// used for validation and display purposes.
+func supportedVerticalContentAlignmentValues() []string {
+	// https://adaptivecards.io/explorer/Table.html
+	// https://adaptivecards.io/schemas/adaptive-card.json
+	return []string{
+		VerticalAlignmentTop,
+		VerticalAlignmentCenter,
+		VerticalAlignmentBottom,
 	}
 }
 
@@ -197,6 +223,8 @@ func supportedStyleValues(elementType string) []string {
 	case TypeElementColumnSet:
 		return supportedContainerStyleValues()
 	case TypeElementContainer:
+		return supportedContainerStyleValues()
+	case TypeElementTable:
 		return supportedContainerStyleValues()
 	case TypeElementImage:
 		return supportedImageStyleValues()

--- a/examples/adaptivecard/table-manually-created/main.go
+++ b/examples/adaptivecard/table-manually-created/main.go
@@ -1,0 +1,211 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+This is an example of a client application which uses this library to generate
+a message with a table within a specific Microsoft Teams channel.
+
+Of note:
+
+- default timeout
+- package-level logging is disabled by default
+- validation of known webhook URL prefixes is *enabled*
+- message is in Adaptive Card format
+- text is unformatted
+- a small table is added to the message
+
+See https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/text-features
+for the list of supported Adaptive Card text formatting options.
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
+)
+
+func main() {
+
+	// Initialize a new Microsoft Teams client.
+	mstClient := goteamsnotify.NewTeamsClient()
+
+	// Set webhook url.
+	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	card := adaptivecard.Card{
+		Type:    adaptivecard.TypeAdaptiveCard,
+		Schema:  adaptivecard.AdaptiveCardSchema,
+		Version: fmt.Sprintf(adaptivecard.AdaptiveCardVersionTmpl, adaptivecard.AdaptiveCardMaxVersion),
+		Body: []adaptivecard.Element{
+			{
+				Type:              adaptivecard.TypeElementTable,
+				GridStyle:         adaptivecard.ContainerStyleAccent,
+				ShowGridLines:     func() *bool { show := false; return &show }(),
+				FirstRowAsHeaders: func() *bool { show := false; return &show }(),
+				Columns: []adaptivecard.Column{
+					{
+						Type:                           adaptivecard.TypeTableColumnDefinition,
+						Width:                          1,
+						HorizontalCellContentAlignment: adaptivecard.HorizontalAlignmentLeft,
+						VerticalCellContentAlignment:   adaptivecard.VerticalAlignmentBottom,
+					},
+					{
+						Type:                           adaptivecard.TypeTableColumnDefinition,
+						Width:                          1,
+						HorizontalCellContentAlignment: adaptivecard.HorizontalAlignmentCenter,
+						VerticalCellContentAlignment:   adaptivecard.VerticalAlignmentCenter,
+					},
+					{
+						Type:                           adaptivecard.TypeTableColumnDefinition,
+						Width:                          1,
+						HorizontalCellContentAlignment: adaptivecard.HorizontalAlignmentRight,
+						VerticalCellContentAlignment:   adaptivecard.VerticalAlignmentBottom,
+					},
+				},
+				Rows: []adaptivecard.TableRow{
+					{
+						Type: adaptivecard.TypeTableRow,
+						Cells: []adaptivecard.TableCell{
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Column 1 header",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Column 2 header",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Column 3 header",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: adaptivecard.TypeTableRow,
+						Cells: []adaptivecard.TableCell{
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: adaptivecard.TypeTableRow,
+						Cells: []adaptivecard.TableCell{
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+							{
+								Type: adaptivecard.TypeTableCell,
+								Items: []*adaptivecard.Element{
+									{
+										Type: adaptivecard.TypeElementTextBlock,
+										Wrap: true,
+										Text: "Table cell test!",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	msg := &adaptivecard.Message{
+		Type: adaptivecard.TypeMessage,
+	}
+
+	msg.Attach(card)
+
+	if err := msg.Prepare(); err != nil {
+		log.Printf(
+			"failed to prepare message payload: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+	fmt.Println(msg.PrettyPrint())
+
+	// Having this here makes it easy to comment out the mstClient.Send block.
+	_ = mstClient
+	_ = webhookUrl
+
+	// Send the message with default timeout/retry settings.
+	if err := mstClient.Send(webhookUrl, msg); err != nil {
+		log.Printf(
+			"failed to send message: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/examples/adaptivecard/table-unordered-grid/main.go
+++ b/examples/adaptivecard/table-unordered-grid/main.go
@@ -1,0 +1,108 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+This is an example of a client application which uses this library to generate
+a message with a table within a specific Microsoft Teams channel.
+
+Of note:
+
+- default timeout
+- package-level logging is disabled by default
+- validation of known webhook URL prefixes is *enabled*
+- message is in Adaptive Card format
+- text is unformatted
+- a table in "grid" format is added to the message
+
+See https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/text-features
+for the list of supported Adaptive Card text formatting options.
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
+)
+
+func main() {
+
+	// Initialize a new Microsoft Teams client.
+	mstClient := goteamsnotify.NewTeamsClient()
+
+	// Set webhook url.
+	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	vals := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	items := make([]interface{}, len(vals))
+
+	// Create a slice of interface values from our input values.
+	for i := range vals {
+		items[i] = vals[i]
+	}
+
+	tableCells, err := adaptivecard.NewTableCellsWithTextBlock(items)
+	if err != nil {
+		log.Printf(
+			"failed to create table cells: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	card := adaptivecard.NewCard()
+
+	// Attach several tables to our card, each with a separator, each showing
+	// a custom number of cells per row.
+	cellsPerRowExamples := []int{2, 4, 6, 8, 10}
+	for _, perRow := range cellsPerRowExamples {
+		table, err := adaptivecard.NewTableWithGridFromTableCells(tableCells, perRow)
+		if err != nil {
+			log.Printf(
+				"failed to create table: %v",
+				err,
+			)
+			os.Exit(1)
+		}
+
+		table.Separator = true
+
+		card.Body = append(card.Body, table)
+	}
+
+	msg := &adaptivecard.Message{
+		Type: adaptivecard.TypeMessage,
+	}
+
+	msg.Attach(card)
+
+	if err := msg.Prepare(); err != nil {
+		log.Printf(
+			"failed to prepare message payload: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	fmt.Println(msg.PrettyPrint())
+
+	// Having this here makes it easy to comment out the mstClient.Send block.
+	_ = mstClient
+	_ = webhookUrl
+
+	// Send the message with default timeout/retry settings.
+	if err := mstClient.Send(webhookUrl, msg); err != nil {
+		log.Printf(
+			"failed to send message: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+}

--- a/examples/adaptivecard/table-with-headers/main.go
+++ b/examples/adaptivecard/table-with-headers/main.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+This is an example of a client application which uses this library to generate
+a message with a table within a specific Microsoft Teams channel.
+
+Of note:
+
+- default timeout
+- package-level logging is disabled by default
+- validation of known webhook URL prefixes is *enabled*
+- message is in Adaptive Card format
+- text is unformatted
+- a table with headers is added to the message
+
+See https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/text-features
+for the list of supported Adaptive Card text formatting options.
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
+)
+
+func main() {
+
+	// Initialize a new Microsoft Teams client.
+	mstClient := goteamsnotify.NewTeamsClient()
+
+	// Set webhook url.
+	webhookUrl := "https://outlook.office.com/webhook/YOUR_WEBHOOK_URL_OF_TEAMS_CHANNEL"
+
+	vals := [][]string{
+		{"column1", "column2", "column3"},
+		{
+			"row 1, value 1",
+			"row 1, value 2",
+			"row 1, value 3",
+		},
+		{
+			"",
+			"",
+			"",
+		},
+		{
+			"row 3, value 1",
+			"row 3, value 2",
+			"row 3, value 3",
+		},
+	}
+
+	cellsCollection := make([][]adaptivecard.TableCell, 0, len(vals))
+
+	for _, row := range vals {
+		items := make([]interface{}, len(row))
+		for i := range row {
+			items[i] = row[i]
+		}
+
+		tableCells, err := adaptivecard.NewTableCellsWithTextBlock(items)
+		if err != nil {
+			log.Printf(
+				"failed to create table cells: %v",
+				err,
+			)
+			os.Exit(1)
+		}
+
+		cellsCollection = append(cellsCollection, tableCells)
+	}
+
+	table, err := adaptivecard.NewTableFromTableCells(cellsCollection, 0, true, true)
+	if err != nil {
+		log.Printf(
+			"failed to create table: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	card := adaptivecard.NewCard()
+
+	card.Body = append(card.Body, table)
+
+	msg := &adaptivecard.Message{
+		Type: adaptivecard.TypeMessage,
+	}
+
+	msg.Attach(card)
+
+	if err := msg.Prepare(); err != nil {
+		log.Printf(
+			"failed to prepare message payload: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+	fmt.Println(msg.PrettyPrint())
+
+	// Having this here makes it easy to comment out the mstClient.Send block.
+	_ = mstClient
+	_ = webhookUrl
+
+	// Send the message with default timeout/retry settings.
+	if err := mstClient.Send(webhookUrl, msg); err != nil {
+		log.Printf(
+			"failed to send message: %v",
+			err,
+		)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Overview

Add early implementation of Adaptive Card Table support.

## Changes

- Expand base/shared Element type with fields specific to the Table type
- Refresh documentation for Column type to note that it serves a dual role
  - member of a ColumnSet
  - member of a Table (TableColumnDefinition)
- Add new types specific to tables
- Examples
  - add example of manually creating a table
  - add example of creating a table with headers
  - add example of creating a table of unordered "grid" values
- README
  - Add references to new examples
  - Add Table element documentation reference

## Limitations

Support for Adaptive Card Table elements is new. There are likely sharp edges and missing support. [Feedback is welcome](https://github.com/atc0005/go-teams-notify/issues/205).

## References

- refs GH-205
- https://adaptivecards.io/explorer/Table.html