### PR TITLE
Add `quick` Makefile recipe (alias)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,11 @@ pristine: goclean gitclean
 all: clean build
 	@echo "Completed build process ..."
 
+.PHONY: quick
+## quick: alias for build recipe
+quick: clean build
+	@echo "Completed tasks for quick build"
+
 .PHONY: build
 ## build: ensure that packages build
 build:


### PR DESCRIPTION
Add this alias to match other projects that I maintain (match shared CI task expectations).