### PR TITLE
Disable unsupported build opts in monthly workflow

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -15,7 +15,15 @@ on:
     # * * * * *
     - cron: "30 4 1 * *"
 
+  # Allow triggering workflow manually
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
 jobs:
   monthly:
     name: Monthly Tasks
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master
+    with:
+      build-packages: false
+      build-podman-release: false
+


### PR DESCRIPTION
- explicitly disable building packages
- explicitly disable generating release builds using podman
- configure workflow_displatch event to permit on-demand workflow runs for future troubleshooting purposes