### PR TITLE
Fix message rendering bug of MS Teams in potential actions

### DIFF
--- a/messagecard/messagecard.go
+++ b/messagecard/messagecard.go
@@ -124,7 +124,7 @@ type PotentialActionActionCard struct {
 
 	// Actions are the available actions. Only used for ActionCard action
 	// type.
-	Actions []PotentialActionActionCardAction `json:"actions,omitempty" yaml:"actions,omitempty"`
+	Actions []PotentialActionActionCardAction `json:"actions" yaml:"actions"`
 }
 
 // PotentialActionActionCardAction is used for configuring ActionCard actions


### PR DESCRIPTION
Hello,

since some days a couple of our messagecards are not rendered anymore in updated MS Teams with the following error message:

![image](https://github.com/atc0005/go-teams-notify/assets/5812215/8a328ea3-015b-4313-bdb4-b7398242243c)

I've debugged the issue and apparently Microsoft changed the schema to require the actions field in PotentialActionActionCard.

To reproduce, the following messagecard is not rendered in the new MS Teams (just send it against a webhook):

```
{
    "@type": "MessageCard",
    "@context": "https://schema.org/extensions",
    "summary": "Test",
    "title": "Test",
    "themeColor": "FFFF00",
    "potentialAction": [
        {
            "@type": "ActionCard",
            "name": "Show",
            "inputs": [
                {
                    "@type": "TextInput",
                    "id": "textinput",
                    "title": "Textinput"
                }
            ]
        }
    ]
}
```

While this one is:

```
{
    "@type": "MessageCard",
    "@context": "https://schema.org/extensions",
    "summary": "Test",
    "title": "Test",
    "themeColor": "FFFF00",
    "potentialAction": [
        {
            "@type": "ActionCard",
            "name": "Show",
            "inputs": [
                {
                    "@type": "TextInput",
                    "id": "textinput",
                    "title": "Textinput"
                }
            ],
            "actions": []
        }
    ]
}
```

The PR should fix the issue, however I could not test it properly (since I failed to hook up my fork of this library to my application, I am not very versed in Golang).