### PR TITLE
Add `IsSublte` and `HorizontalAlignment` to `Element`

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -198,7 +198,8 @@ const (
 	SpacingPadding    string = "padding"
 )
 
-// Supported Horizontal alignment values for (supported) container types.
+// Supported Horizontal alignment values for (supported) container and text
+// types.
 const (
 	HorizontalAlignmentLeft   string = "left"
 	HorizontalAlignmentCenter string = "center"
@@ -502,6 +503,9 @@ type Element struct {
 	// preceding element.
 	Spacing string `json:"spacing,omitempty"`
 
+	// HorizontalAlignment controls the horizontal text alignment.
+	HorizontalAlignment string `json:"horizontalAlignment,omitempty"`
+
 	// The style of the element for accessibility purposes. Valid values
 	// differ based on the element type. For example, a TextBlock element
 	// supports the "heading" style, whereas the Column element supports the
@@ -583,6 +587,10 @@ type Element struct {
 	// Wrap controls whether text is allowed to wrap or is clipped for
 	// TextBlock elements.
 	Wrap bool `json:"wrap,omitempty"`
+
+	// IsSubtle specifies whether this element should appear slightly toned
+	// down.
+	IsSubtle bool `json:"isSubtle,omitempty"`
 
 	// Separator, when true, indicates that a separating line shown should be
 	// drawn at the top of the element.
@@ -1281,6 +1289,7 @@ func (e Element) Validate() error {
 	supportedWeightValues := supportedWeightValues()
 	supportedColorValues := supportedColorValues()
 	supportedSpacingValues := supportedSpacingValues()
+	supportedHorizontalAlignmentValues := supportedHorizontalAlignmentValues()
 
 	// Valid Style field values differ based on type. For example, a Container
 	// element supports Container styles whereas a TextBlock supports a
@@ -1297,6 +1306,7 @@ func (e Element) Validate() error {
 	v.InListIfFieldValNotEmpty(e.Weight, "Weight", "element", supportedWeightValues, ErrInvalidFieldValue)
 	v.InListIfFieldValNotEmpty(e.Color, "Color", "element", supportedColorValues, ErrInvalidFieldValue)
 	v.InListIfFieldValNotEmpty(e.Spacing, "Spacing", "element", supportedSpacingValues, ErrInvalidFieldValue)
+	v.InListIfFieldValNotEmpty(e.HorizontalAlignment, "HorizontalAlignment", "element", supportedHorizontalAlignmentValues, ErrInvalidFieldValue)
 	v.InListIfFieldValNotEmpty(e.Style, "Style", "element", supportedStyleValues, ErrInvalidFieldValue)
 
 	/******************************************************************
@@ -1443,7 +1453,7 @@ func (tcd TableColumnDefinition) Validate() error {
 		tcd.HorizontalCellContentAlignment,
 		"HorizontalCellContentAlignment",
 		TypeTableColumnDefinition,
-		supportedHorizontalContentAlignmentValues(),
+		supportedHorizontalAlignmentValues(),
 		ErrInvalidFieldValue,
 	)
 
@@ -1534,7 +1544,7 @@ func (tr TableRow) Validate() error {
 		tr.HorizontalCellContentAlignment,
 		"HorizontalCellContentAlignment",
 		TypeTableRow,
-		supportedHorizontalContentAlignmentValues(),
+		supportedHorizontalAlignmentValues(),
 		ErrInvalidFieldValue,
 	)
 

--- a/adaptivecard/getters.go
+++ b/adaptivecard/getters.go
@@ -95,10 +95,11 @@ func supportedSpacingValues() []string {
 }
 
 // supportedHorizontalAlignmentValues returns a list of valid horizontal
-// content alignment values for supported container types. This list is
+// alignment values for supported container and text types. This list is
 // intended to be used for validation and display purposes.
-func supportedHorizontalContentAlignmentValues() []string {
+func supportedHorizontalAlignmentValues() []string {
 	// https://adaptivecards.io/explorer/Table.html
+	// https://adaptivecards.io/explorer/TextBlock.html
 	// https://adaptivecards.io/schemas/adaptive-card.json
 	return []string{
 		HorizontalAlignmentLeft,


### PR DESCRIPTION
This PR adds two fields to the `Element` struct:
- `IsSubtle`: For setting subtle text appearance
- `HorizontalAlignment`: For setting the horizontal alignment of text elements

Reference: https://adaptivecards.io/explorer/TextBlock.html

I reused the horizontal alignment values from `Column.HorizontalCellContentAlignment` as the values are the same and I felt that having something like `HorizontalTextAlignmentLeft` would cause confusion when the field itself is called `HorizontalAlignment`.

Closes #254 