### PR TITLE
Remove inactive maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,10 +17,6 @@ linters:
     - gofmt
     - revive
     - gosec
-
-    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
-    # See https://github.com/atc0005/go-ci/issues/302 for more information.
-    - maligned
     - nakedret
     - prealloc
     - exportloopref
@@ -40,10 +36,6 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 15
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
 
   nakedret:
     # make an issue if func has more lines of code than this setting and it has naked returns; default is 30


### PR DESCRIPTION
This linter has been deprecated for a while with the suggestion to use govet 'fieldalignment'.

As of a recent release the linter no longer produced a report.

As of the v1.59.0 release attempting to use this linter produces an error.

Remove all references to this linter from the .golangci.yml config file bundled in this repo.