### PR TITLE
Fix validation for `Action.Type` field

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -1934,12 +1934,6 @@ func (a Action) Validate() error {
 	// Optional, but only supported by the Action.ShowCard type.
 	case a.Card != nil:
 		v.FieldHasSpecificValue(a.Type, "type", TypeActionShowCard, "type", ErrInvalidType)
-
-		return fmt.Errorf(
-			"error: specifying a Card is unsupported for Action type %q: %w",
-			a.Type,
-			ErrInvalidFieldValue,
-		)
 	}
 
 	// Return the last recorded validation error, or nil if no validation


### PR DESCRIPTION
## Changes

The now removed error handling was used prior to refactoring applied in commit 7ef6d5203f760f07ad704fb027f4f7ff2696fcc8.

credit: Thanks to @ArcticXWolf for reporting this.

## References

- GH-268
- GH-251