### PR TITLE
Add initial support for Workflow connectors

### DIFF
--- a/adaptivecard/adaptivecard.go
+++ b/adaptivecard/adaptivecard.go
@@ -49,7 +49,13 @@ const (
 	//
 	// https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#support-for-adaptive-cards
 	// https://adaptivecards.io/designer
-	AdaptiveCardMaxVersion  float64 = 1.5
+	//
+	// NOTE: Documented as 1.5 (adaptivecards.io/designer), but in practice >
+	// 1.4 is rejected for Power Automate workflow connectors.
+	//
+	// Setting to 1.4 works both for legacy O365 connectors and Workflow
+	// connectors.
+	AdaptiveCardMaxVersion  float64 = 1.4
 	AdaptiveCardMinVersion  float64 = 1.0
 	AdaptiveCardVersionTmpl string  = "%0.1f"
 )

--- a/send.go
+++ b/send.go
@@ -36,7 +36,7 @@ const (
 
 // Known Workflow URL patterns for submitting messages to Microsoft Teams.
 const (
-	WorkflowURLBaseDomain = "logic.azure.com"
+	WorkflowURLBaseDomain = `^https:\/\/(?:.*)(:?\.azure-api|logic\.azure)\.(?:com|net)`
 )
 
 // DisableWebhookURLValidation is a special keyword used to indicate to


### PR DESCRIPTION
## Changes

- lower `AdaptiveCardMaxVersion` from `1.5` to `1.4`
  - this almost seems like a bug on Teams' end as this limitation is not communicated (from what I could tell) via https://adaptivecards.io/designer/
  - using a value of `1.4` appears to work equally well for O365 and Workflow connectors
- treat a 202 response code as sufficient response verification
  - instead of expecting a `1` in the response body as previously confirmed
  - see also atc0005/go-teams-notify#59
- add `logic.azure.com` to valid URL patterns for default validation
  - refactored in a later commit to match either of `logic.azure.com` or `*.azure-api.net` as observed in the wild
- debugging / troubleshooting - log status code and response string for O365 connector responses - log validation pattern match

## References

- fixes GH-262