### PR TITLE
Refactor regex for default Workflow URLs

### DIFF
--- a/send.go
+++ b/send.go
@@ -36,7 +36,7 @@ const (
 
 // Known Workflow URL patterns for submitting messages to Microsoft Teams.
 const (
-	WorkflowURLBaseDomain = "logic.azure.com"
+	WorkflowURLBaseDomain = `^https:\/\/(?:.*\.azure-api|logic\.azure)\.(?:com|net)`
 )
 
 // DisableWebhookURLValidation is a special keyword used to indicate to


### PR DESCRIPTION
Switch from static base pattern of `logic.azure.com` to a regex OR pattern to permit either of `logic.azure.com` or `*.azure-api.net` as has been observed in the wild.

This also has the side effect of resolving potential CodeQL alerts raised in PR GH-275.

refs GH-262