### PR TITLE
Update CodeQL workflow to run on dev branch PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - development
 
   pull_request:
     # `synchronized` seems to equate to pushing new commits to a linked branch
@@ -17,7 +19,9 @@ on:
     types: [opened, synchronize]
 
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - master
+      - development
 
   schedule:
     - cron: "00 4 * * 0"


### PR DESCRIPTION
Run CodeQL jobs for `development` branch in addition to the current stable branch.

refs GH-276