### PR TITLE
fix: adjust WorkflowURLBaseDomain for both new and old urls

### DIFF
--- a/send.go
+++ b/send.go
@@ -36,7 +36,7 @@ const (
 
 // Known Workflow URL patterns for submitting messages to Microsoft Teams.
 const (
-	WorkflowURLBaseDomain = `^https:\/\/(?:.*)(:?\.azure-api|logic\.azure)\.(?:com|net)`
+	WorkflowURLBaseDomain = `^https:\/\/(?:.*)(:?\.azure-api|logic\.azure|api\.powerplatform)\.(?:com|net)`
 )
 
 // DisableWebhookURLValidation is a special keyword used to indicate to

--- a/send_test.go
+++ b/send_test.go
@@ -178,6 +178,17 @@ func TestTeamsClientSend(t *testing.T) {
 			skipURLVal:            false,
 			validationURLPatterns: []string{`^https://.*\.domain\.com/.*$`},
 		},
+		{
+			name:                  "ms teams workflow webhook request with default patterns",
+			reqURL:                "https://default123xxxx.de.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1x2x3x4x5/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=xxxx",
+			reqMsg:                simpleMsgCard,
+			resStatus:             200,
+			resBody:               ExpectedWebhookURLResponseText,
+			resError:              nil,
+			error:                 nil,
+			skipURLVal:            false,
+			validationURLPatterns: []string{DefaultWebhookURLValidationPattern, WorkflowURLBaseDomain},
+		},
 	}
 	for idx, test := range tests {
 		// Create range scoped var for use within closure


### PR DESCRIPTION
I couldn't find any contribution guidelines so I'm open to any feedback.

Changelog:
- Add:
  - Added extra test case for the change
- Change:
  - Adjusted the regex pattern in `WorkflowURLBaseDomain` to allow the new webhook URL structure
- Removed: N/A

Closes #310 